### PR TITLE
Wrapped $query->term_id use in isset due to error on custom taxonomy archive

### DIFF
--- a/modules/display-by-query/display-by-query.class.php
+++ b/modules/display-by-query/display-by-query.class.php
@@ -50,7 +50,7 @@ class Advanced_Ads_Module_Display_By_Query {
                 $args['wp_the_query'] = array();
             }
             $query = $wp_the_query->get_queried_object();
-            if ( ! isset( $args['wp_the_query']['term_id'] ) && $query ) {
+            if ( ! isset( $args['wp_the_query']['term_id'] ) && isset( $query->term_id ) ) {
                 $args['wp_the_query']['term_id'] = $query->term_id;
             }
 


### PR DESCRIPTION
I was consistently seeing a `Undefined property: stdClass::$term_id` error when advanced ad placements were put in the template on custom taxonomy archive pages. I'm not sure if this solution works for you but I wrapped `$query->term_id` in an `isset()` to solve it.
